### PR TITLE
Remove useless cloning

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -377,6 +377,6 @@ final class Version
      */
     public function withBuild($build)
     {
-        return self::fromAllElements($this->major, $this->minor, $this->patch, clone $this->preRelease, $build);
+        return self::fromAllElements($this->major, $this->minor, $this->patch, $this->preRelease, $build);
     }
 }


### PR DESCRIPTION
As the value objects are immutable, the same instance can be reused instead of creating a new one
