### PR TITLE
Greater usability of a VersionsCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $versions = new VersionsCollection(
 
 echo count($versions); //3
 
-$versions = $versions->sorted(VersionsCollection::SORT_DESC);
+$versions = $versions->sortedDescending(VersionsCollection::SORT_DESC);
 
 //Outputs: 2.3.3, 1.1.0, 1.0.0
 foreach ($versions as $version) {

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $versions = new VersionsCollection(
 
 echo count($versions); //3
 
-$versions->sort(VersionsCollection::SORT_DESC);
+$versions = $versions->sorted(VersionsCollection::SORT_DESC);
 
 //Outputs: 2.3.3, 1.1.0, 1.0.0
 foreach ($versions as $version) {

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $versions = new VersionsCollection(
 
 echo count($versions); //3
 
-$versions = $versions->sortedDescending(VersionsCollection::SORT_DESC);
+$versions = $versions->sortedDescending();
 
 //Outputs: 2.3.3, 1.1.0, 1.0.0
 foreach ($versions as $version) {

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ $versions = $versions->sortedDescending(VersionsCollection::SORT_DESC);
 foreach ($versions as $version) {
     echo (string) $version;
 }
+
+$minorReleases = $versions->minorReleases();
+echo $minorReleases->first(); //1.1.0
 ```
 
 ## Credits

--- a/src/Exception/CollectionIsEmptyException.php
+++ b/src/Exception/CollectionIsEmptyException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Version\Exception;
+
+use LogicException;
+
+class CollectionIsEmptyException extends LogicException implements ExceptionInterface
+{
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -122,16 +122,6 @@ class Version implements JsonSerializable
         return $this->build;
     }
 
-    public function isPreRelease() : bool
-    {
-        return !$this->preRelease->isEmpty();
-    }
-
-    public function isBuild() : bool
-    {
-        return !$this->build->isEmpty();
-    }
-
     /**
      * @param Version|string $version
      * @return bool
@@ -199,6 +189,35 @@ class Version implements JsonSerializable
         return $this->getComparator()->compare($this, $version);
     }
 
+    public function isMinor() : bool
+    {
+        return $this->minor > 0;
+    }
+
+    public function isPatch() : bool
+    {
+        return $this->patch > 0;
+    }
+
+    public function isPreRelease() : bool
+    {
+        return !$this->preRelease->isEmpty();
+    }
+
+    /**
+     * @deprecated Use hasBuild() instead
+     * @return bool
+     */
+    public function isBuild() : bool
+    {
+        return !$this->build->isEmpty();
+    }
+
+    public function hasBuild() : bool
+    {
+        return !$this->build->isEmpty();
+    }
+
     public function incrementMajor() : Version
     {
         return static::fromParts($this->major + 1, 0, 0, new NoPreRelease(), new NoBuild());
@@ -252,7 +271,7 @@ class Version implements JsonSerializable
             . '.' . $this->minor
             . '.' . $this->patch
             . ($this->isPreRelease() ? '-' . (string) $this->preRelease : '')
-            . ($this->isBuild() ? '+' . (string) $this->build : '')
+            . ($this->hasBuild() ? '+' . (string) $this->build : '')
         ;
     }
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -189,16 +189,6 @@ class Version implements JsonSerializable
         return $this->getComparator()->compare($this, $version);
     }
 
-    public function isMinor() : bool
-    {
-        return $this->minor > 0;
-    }
-
-    public function isPatch() : bool
-    {
-        return $this->patch > 0;
-    }
-
     public function isPreRelease() : bool
     {
         return !$this->preRelease->isEmpty();

--- a/src/Version.php
+++ b/src/Version.php
@@ -189,6 +189,21 @@ class Version implements JsonSerializable
         return $this->getComparator()->compare($this, $version);
     }
 
+    public function isMajorRelease() : bool
+    {
+        return $this->major > 0 && $this->minor === 0 && $this->patch === 0;
+    }
+
+    public function isMinorRelease() : bool
+    {
+        return $this->minor > 0 && $this->patch === 0;
+    }
+
+    public function isPatchRelease() : bool
+    {
+        return $this->patch > 0;
+    }
+
     public function isPreRelease() : bool
     {
         return !$this->preRelease->isEmpty();

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -73,6 +73,9 @@ class VersionsCollection implements Countable, IteratorAggregate
         ));
     }
 
+    /**
+     * @return Version[]
+     */
     public function toArray() : array
     {
         return $this->versions;

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -110,6 +110,26 @@ class VersionsCollection implements Countable, IteratorAggregate
         ));
     }
 
+    public function filterMinor() : VersionsCollection
+    {
+        return new static(...array_filter(
+            $this->versions,
+            function (Version $version) {
+                return $version->isMinor();
+            }
+        ));
+    }
+
+    public function filterPatch() : VersionsCollection
+    {
+        return new static(...array_filter(
+            $this->versions,
+            function (Version $version) {
+                return $version->isPatch();
+            }
+        ));
+    }
+
     /**
      * @return Version[]
      */

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -72,4 +72,9 @@ class VersionsCollection implements Countable, IteratorAggregate
             }
         ));
     }
+
+    public function toArray() : array
+    {
+        return $this->versions;
+    }
 }

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -33,6 +33,11 @@ class VersionsCollection implements Countable, IteratorAggregate
         return count($this->versions);
     }
 
+    public function isEmpty() : bool
+    {
+        return 0 === $this->count();
+    }
+
     public function getIterator() : Traversable
     {
         return new ArrayIterator($this->versions);

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -28,13 +28,6 @@ class VersionsCollection implements Countable, IteratorAggregate
         $this->versions = $versions;
     }
 
-    public static function fromStrings(string ...$versionStrings) : VersionsCollection
-    {
-        return new static(...array_map(function ($versionString) {
-            return Version::fromString($versionString);
-        }, $versionStrings));
-    }
-
     public function count() : int
     {
         return count($this->versions);

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -43,6 +43,9 @@ class VersionsCollection implements Countable, IteratorAggregate
         return new ArrayIterator($this->versions);
     }
 
+    /**
+     * @deprecated This method will be removed in 4.0.0. Use sorted() instead.
+     */
     public function sort(string $direction = self::SORT_ASC) : void
     {
         usort($this->versions, function (Version $a, Version $b) use ($direction) {
@@ -54,6 +57,23 @@ class VersionsCollection implements Countable, IteratorAggregate
 
             return $result;
         });
+    }
+
+    public function sorted(string $direction = self::SORT_ASC) : VersionsCollection
+    {
+        $versions = $this->versions;
+
+        usort($versions, function (Version $a, Version $b) use ($direction) {
+            $result = $a->compareTo($b);
+
+            if ($direction === self::SORT_DESC) {
+                $result *= -1;
+            }
+
+            return $result;
+        });
+
+        return new static(...$versions);
     }
 
     public function matching(ConstraintInterface $constraint) : VersionsCollection

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -69,18 +69,23 @@ class VersionsCollection implements Countable, IteratorAggregate
         });
     }
 
-    public function sorted(string $direction = self::SORT_ASC) : VersionsCollection
+    public function sortedAscending() : VersionsCollection
     {
         $versions = $this->versions;
 
-        usort($versions, function (Version $a, Version $b) use ($direction) {
-            $result = $a->compareTo($b);
+        usort($versions, function (Version $a, Version $b) {
+            return $a->compareTo($b);
+        });
 
-            if ($direction === self::SORT_DESC) {
-                $result *= -1;
-            }
+        return new static(...$versions);
+    }
 
-            return $result;
+    public function sortedDescending() : VersionsCollection
+    {
+        $versions = $this->versions;
+
+        usort($versions, function (Version $a, Version $b) {
+            return $a->compareTo($b) * -1;
         });
 
         return new static(...$versions);

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -9,6 +9,7 @@ use IteratorAggregate;
 use ArrayIterator;
 use Traversable;
 use Version\Constraint\ConstraintInterface;
+use Version\Exception\CollectionIsEmptyException;
 
 /**
  * @author Nikola Posa <posa.nikola@gmail.com>
@@ -38,14 +39,22 @@ class VersionsCollection implements Countable, IteratorAggregate
         return empty($this->versions);
     }
 
-    public function first() : ?Version
+    public function first() : Version
     {
-        return $this->versions[0] ?? null;
+        if (empty($this->versions)) {
+            throw new CollectionIsEmptyException('Invoking first() on an empty collection');
+        }
+
+        return $this->versions[0];
     }
 
-    public function last() : ?Version
+    public function last() : Version
     {
-        return $this->versions[count($this->versions) - 1] ?? null;
+        if (empty($this->versions)) {
+            throw new CollectionIsEmptyException('Invoking last() on an empty collection');
+        }
+
+        return $this->versions[count($this->versions) - 1];
     }
 
     public function getIterator() : Traversable

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -110,22 +110,32 @@ class VersionsCollection implements Countable, IteratorAggregate
         ));
     }
 
-    public function filterMinor() : VersionsCollection
+    public function majorReleases() : VersionsCollection
     {
         return new static(...array_filter(
             $this->versions,
             function (Version $version) {
-                return $version->isMinor();
+                return $version->getMajor() > 0 && $version->getMinor() === 0 && $version->getPatch() === 0;
             }
         ));
     }
 
-    public function filterPatch() : VersionsCollection
+    public function minorReleases() : VersionsCollection
     {
         return new static(...array_filter(
             $this->versions,
             function (Version $version) {
-                return $version->isPatch();
+                return $version->getMinor() > 0 && $version->getPatch() === 0;
+            }
+        ));
+    }
+
+    public function patchReleases() : VersionsCollection
+    {
+        return new static(...array_filter(
+            $this->versions,
+            function (Version $version) {
+                return $version->getPatch() > 0;
             }
         ));
     }

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -42,7 +42,7 @@ class VersionsCollection implements Countable, IteratorAggregate
 
     public function isEmpty() : bool
     {
-        return 0 === $this->count();
+        return empty($this->versions);
     }
 
     public function getIterator() : Traversable

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -38,6 +38,16 @@ class VersionsCollection implements Countable, IteratorAggregate
         return empty($this->versions);
     }
 
+    public function first() : ?Version
+    {
+        return $this->versions[0] ?? null;
+    }
+
+    public function last() : ?Version
+    {
+        return $this->versions[count($this->versions) - 1] ?? null;
+    }
+
     public function getIterator() : Traversable
     {
         return new ArrayIterator($this->versions);

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -28,6 +28,13 @@ class VersionsCollection implements Countable, IteratorAggregate
         $this->versions = $versions;
     }
 
+    public static function fromStrings(string ...$versionStrings) : VersionsCollection
+    {
+        return new static(...array_map(function ($versionString) {
+            return Version::fromString($versionString);
+        }, $versionStrings));
+    }
+
     public function count() : int
     {
         return count($this->versions);

--- a/src/VersionsCollection.php
+++ b/src/VersionsCollection.php
@@ -115,7 +115,7 @@ class VersionsCollection implements Countable, IteratorAggregate
         return new static(...array_filter(
             $this->versions,
             function (Version $version) {
-                return $version->getMajor() > 0 && $version->getMinor() === 0 && $version->getPatch() === 0;
+                return $version->isMajorRelease();
             }
         ));
     }
@@ -125,7 +125,7 @@ class VersionsCollection implements Countable, IteratorAggregate
         return new static(...array_filter(
             $this->versions,
             function (Version $version) {
-                return $version->getMinor() > 0 && $version->getPatch() === 0;
+                return $version->isMinorRelease();
             }
         ));
     }
@@ -135,7 +135,7 @@ class VersionsCollection implements Countable, IteratorAggregate
         return new static(...array_filter(
             $this->versions,
             function (Version $version) {
-                return $version->getPatch() > 0;
+                return $version->isPatchRelease();
             }
         ));
     }

--- a/tests/TestAsset/VersionIsIdentical.php
+++ b/tests/TestAsset/VersionIsIdentical.php
@@ -34,16 +34,16 @@ final class VersionIsIdentical extends Constraint
         );
     }
 
-    protected function matches($constraint) : bool
+    protected function matches($version) : bool
     {
-        /* @var $constraint Version */
+        /* @var $version Version */
 
         return (
-            $constraint->getMajor() === $this->expectedVersion->getMajor()
-            && $constraint->getMinor() === $this->expectedVersion->getMinor()
-            && $constraint->getPatch() === $this->expectedVersion->getPatch()
-            && $constraint->getPreRelease()->getIdentifiers() === $this->expectedVersion->getPreRelease()->getIdentifiers()
-            && $constraint->getBuild()->getIdentifiers() === $this->expectedVersion->getBuild()->getIdentifiers()
+            $version->getMajor() === $this->expectedVersion->getMajor()
+            && $version->getMinor() === $this->expectedVersion->getMinor()
+            && $version->getPatch() === $this->expectedVersion->getPatch()
+            && $version->getPreRelease()->getIdentifiers() === $this->expectedVersion->getPreRelease()->getIdentifiers()
+            && $version->getBuild()->getIdentifiers() === $this->expectedVersion->getBuild()->getIdentifiers()
         );
     }
 

--- a/tests/TestAsset/VersionsCollectionIsIdentical.php
+++ b/tests/TestAsset/VersionsCollectionIsIdentical.php
@@ -34,6 +34,10 @@ final class VersionsCollectionIsIdentical extends Constraint
     {
         /* @var $versions VersionsCollection */
 
+        if ($versions->count() !== count($this->isIdenticalConstraints)) {
+            return false;
+        }
+
         foreach ($versions->toArray() as $i => $version) {
             /* @var $version Version */
 

--- a/tests/TestAsset/VersionsCollectionIsIdentical.php
+++ b/tests/TestAsset/VersionsCollectionIsIdentical.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Version\Tests\TestAsset;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Version\Version;
+use Version\VersionsCollection;
+
+final class VersionsCollectionIsIdentical extends Constraint
+{
+    /**
+     * @var VersionIsIdentical[]
+     */
+    private $isIdenticalConstraints;
+
+    public function __construct(array $expectedVersions)
+    {
+        parent::__construct();
+
+        foreach ($expectedVersions as [$expectedMajor, $expectedMinor, $expectedPatch, $expectedPreRelease, $expectedBuild]) {
+            $this->isIdenticalConstraints[] = new VersionIsIdentical(
+                $expectedMajor,
+                $expectedMinor,
+                $expectedPatch,
+                $expectedPreRelease,
+                $expectedBuild
+            );
+        }
+    }
+
+    protected function matches($versions) : bool
+    {
+        /* @var $versions VersionsCollection */
+
+        foreach ($versions->toArray() as $i => $version) {
+            /* @var $version Version */
+
+            if (! isset($this->isIdenticalConstraints[$i])) {
+                return false;
+            }
+
+            $isIdenticalConstraint = $this->isIdenticalConstraints[$i];
+
+            if (! $isIdenticalConstraint->evaluate($version, '', true)) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }
+
+    public function toString() : string
+    {
+        return 'content is identical for specified versions';
+    }
+}

--- a/tests/TestAsset/VersionsCollectionIsIdentical.php
+++ b/tests/TestAsset/VersionsCollectionIsIdentical.php
@@ -49,7 +49,6 @@ final class VersionsCollectionIsIdentical extends Constraint
         }
 
         return true;
-
     }
 
     public function toString() : string

--- a/tests/VersionComparisonTest.php
+++ b/tests/VersionComparisonTest.php
@@ -75,22 +75,4 @@ class VersionComparisonTest extends TestCase
     {
         $this->assertTrue(Version::fromString('1.0.0')->isLessOrEqualTo('1.0.0'));
     }
-
-    /**
-     * @test
-     */
-    public function it_checks_whether_it_is_minor() : void
-    {
-        $this->assertFalse(Version::fromString('2.0.0')->isMinor());
-        $this->assertTrue(Version::fromString('2.1.0')->isMinor());
-    }
-
-    /**
-     * @test
-     */
-    public function it_checks_whether_it_is_patch() : void
-    {
-        $this->assertTrue(Version::fromString('1.2.3')->isPatch());
-        $this->assertFalse(Version::fromString('2.1.0')->isPatch());
-    }
 }

--- a/tests/VersionComparisonTest.php
+++ b/tests/VersionComparisonTest.php
@@ -75,4 +75,22 @@ class VersionComparisonTest extends TestCase
     {
         $this->assertTrue(Version::fromString('1.0.0')->isLessOrEqualTo('1.0.0'));
     }
+
+    /**
+     * @test
+     */
+    public function it_checks_whether_it_is_minor() : void
+    {
+        $this->assertFalse(Version::fromString('2.0.0')->isMinor());
+        $this->assertTrue(Version::fromString('2.1.0')->isMinor());
+    }
+
+    /**
+     * @test
+     */
+    public function it_checks_whether_it_is_patch() : void
+    {
+        $this->assertTrue(Version::fromString('1.2.3')->isPatch());
+        $this->assertFalse(Version::fromString('2.1.0')->isPatch());
+    }
 }

--- a/tests/VersionExtensionTest.php
+++ b/tests/VersionExtensionTest.php
@@ -19,6 +19,7 @@ class VersionExtensionTest extends TestCase
     {
         $version = Version::fromString('1.0.0-alpha');
 
+        $this->assertTrue($version->isPreRelease());
         $identifiers = $version->getPreRelease()->getIdentifiers();
         $this->assertCount(1, $identifiers);
         $this->assertSame('alpha', $identifiers[0]);
@@ -45,6 +46,8 @@ class VersionExtensionTest extends TestCase
     {
         $version = Version::fromString('1.0.0+20150919');
 
+        $this->assertTrue($version->hasBuild());
+        $this->assertTrue($version->isBuild());
         $identifiers = $version->getBuild()->getIdentifiers();
         $this->assertCount(1, $identifiers);
         $this->assertSame('20150919', $identifiers[0]);

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -6,6 +6,7 @@ namespace Version\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Version\Exception\InvalidVersionStringException;
+use Version\Tests\TestAsset\VersionIsIdentical;
 use Version\Tests\TestAsset\VersionsCollectionIsIdentical;
 use Version\VersionsCollection;
 use Version\Version;
@@ -89,6 +90,64 @@ class VersionsCollectionTest extends TestCase
         $versions = new VersionsCollection();
 
         $this->assertTrue($versions->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_first_version() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3')
+        );
+
+        $version = $versions->first();
+
+        $this->assertNotNull($version);
+        $this->assertThat($version, new VersionIsIdentical(1, 0, 0));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_first_version_if_collection_is_empty() : void
+    {
+        $versions = new VersionsCollection();
+
+        $version = $versions->first();
+
+        $this->assertNull($version);
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_last_version() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3')
+        );
+
+        $version = $versions->last();
+
+        $this->assertNotNull($version);
+        $this->assertThat($version, new VersionIsIdentical(2, 3, 3));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_null_for_last_version_if_collection_is_empty() : void
+    {
+        $versions = new VersionsCollection();
+
+        $version = $versions->last();
+
+        $this->assertNull($version);
     }
 
     /**

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -308,18 +308,42 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_filters_minor_versions() : void
+    public function it_finds_major_releases() : void
     {
-        $versions = new VersionsCollection(
+        $releases = new VersionsCollection(
             Version::fromString('1.0.0'),
             Version::fromString('1.1.0'),
             Version::fromString('2.0.0'),
-            Version::fromString('2.1.0')
+            Version::fromString('2.1.0'),
+            Version::fromString('3.0.0'),
+            Version::fromString('3.0.1')
         );
 
-        $minorVersions = $versions->filterMinor();
+        $majorReleases = $releases->majorReleases();
 
-        $this->assertThat($minorVersions, new VersionsCollectionIsIdentical([
+        $this->assertThat($majorReleases, new VersionsCollectionIsIdentical([
+            [1, 0, 0, null, null],
+            [2, 0, 0, null, null],
+            [3, 0, 0, null, null],
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_minor_releases() : void
+    {
+        $releases = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.1.0'),
+            Version::fromString('2.1.1')
+        );
+
+        $minorReleases = $releases->minorReleases();
+
+        $this->assertThat($minorReleases, new VersionsCollectionIsIdentical([
             [1, 1, 0, null, null],
             [2, 1, 0, null, null],
         ]));
@@ -328,21 +352,43 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_filters_patch_versions() : void
+    public function it_finds_patch_releases() : void
     {
-        $versions = new VersionsCollection(
+        $releases = new VersionsCollection(
             Version::fromString('1.0.0'),
             Version::fromString('1.0.1'),
             Version::fromString('2.0.0'),
             Version::fromString('2.0.1')
         );
 
-        $patchVersions = $versions->filterPatch();
+        $patchReleases = $releases->patchReleases();
 
-        $this->assertThat($patchVersions, new VersionsCollectionIsIdentical([
+        $this->assertThat($patchReleases, new VersionsCollectionIsIdentical([
             [1, 0, 1, null, null],
             [2, 0, 1, null, null],
         ]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_finds_latest_major_release() : void
+    {
+        $releases = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.1.0'),
+            Version::fromString('3.0.0'),
+            Version::fromString('3.0.1')
+        );
+
+        $latestMajorRelease = $releases
+            ->majorReleases()
+            ->sortedDescending()
+            ->first();
+
+        $this->assertThat($latestMajorRelease, new VersionIsIdentical(3, 0, 0));
     }
 
     /**

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Version\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Version\Exception\CollectionIsEmptyException;
 use Version\Exception\InvalidVersionStringException;
 use Version\Tests\TestAsset\VersionIsIdentical;
 use Version\Tests\TestAsset\VersionsCollectionIsIdentical;
@@ -112,13 +113,17 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_for_first_version_if_collection_is_empty() : void
+    public function it_raises_exception_when_getting_first_item_of_empty_collection() : void
     {
         $versions = new VersionsCollection();
 
-        $version = $versions->first();
+        try {
+            $versions->first();
 
-        $this->assertNull($version);
+            $this->fail('Exception should have been raised');
+        } catch (CollectionIsEmptyException $ex) {
+            $this->assertSame('Invoking first() on an empty collection', $ex->getMessage());
+        }
     }
 
     /**
@@ -141,13 +146,17 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_for_last_version_if_collection_is_empty() : void
+    public function it_raises_exception_when_getting_last_item_of_empty_collection() : void
     {
         $versions = new VersionsCollection();
 
-        $version = $versions->last();
+        try {
+            $versions->last();
 
-        $this->assertNull($version);
+            $this->fail('Exception should have been raised');
+        } catch (CollectionIsEmptyException $ex) {
+            $this->assertSame('Invoking last() on an empty collection', $ex->getMessage());
+        }
     }
 
     /**
@@ -260,6 +269,24 @@ class VersionsCollectionTest extends TestCase
             [2, 0, 0, null, null],
             [2, 0, 1, null, null],
         ]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_gets_first_last_items_after_filtering() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.0.1'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.0.1')
+        );
+
+        $versions2 = $versions->matching(ComparisonConstraint::fromString('>=2.0.0'));
+
+        $this->assertThat($versions2->first(), new VersionIsIdentical(2, 0, 0));
+        $this->assertThat($versions2->last(), new VersionIsIdentical(2, 0, 1));
     }
 
     /**

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Version\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Version\Exception\InvalidVersionStringException;
 use Version\VersionsCollection;
 use Version\Version;
 use Version\Constraint\ComparisonConstraint;
@@ -31,15 +32,25 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_can_be_created_via_named_constructor() : void
+    public function it_can_be_created_from_version_strings() : void
     {
-        $versions = new VersionsCollection(
-            Version::fromParts(1),
-            Version::fromString('1.1.0'),
-            Version::fromString('2.3.3')
-        );
+        $versions = VersionsCollection::fromStrings('1.1.0', '2.3.3');
 
         $this->assertInstanceOf(VersionsCollection::class, $versions);
+    }
+
+    /**
+     * @test
+     */
+    public function it_forwards_invalid_version_string_exception() : void
+    {
+        try {
+            VersionsCollection::fromStrings('1.1.0', 'invalid');
+
+            $this->fail('Exception should have been raised');
+        } catch (InvalidVersionStringException $ex) {
+            $this->assertSame('invalid', $ex->getVersionString());
+        }
     }
 
     /**

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -59,6 +59,16 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
+    public function it_provides_is_empty_check() : void
+    {
+        $versions = new VersionsCollection();
+
+        $this->assertTrue($versions->isEmpty());
+    }
+
+    /**
+     * @test
+     */
     public function it_is_iterable() : void
     {
         $versions = new VersionsCollection(

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -6,6 +6,7 @@ namespace Version\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Version\Exception\InvalidVersionStringException;
+use Version\Tests\TestAsset\VersionsCollectionIsIdentical;
 use Version\VersionsCollection;
 use Version\Version;
 use Version\Constraint\ComparisonConstraint;
@@ -26,7 +27,11 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('2.3.3')
         );
 
-        $this->assertInstanceOf(VersionsCollection::class, $versions);
+        $this->assertThat($versions, new VersionsCollectionIsIdentical([
+            [1, 0, 0, null, null],
+            [1, 1, 0, null, null],
+            [2, 3, 3, null, null],
+        ]));
     }
 
     /**
@@ -36,7 +41,10 @@ class VersionsCollectionTest extends TestCase
     {
         $versions = VersionsCollection::fromStrings('1.1.0', '2.3.3');
 
-        $this->assertInstanceOf(VersionsCollection::class, $versions);
+        $this->assertThat($versions, new VersionsCollectionIsIdentical([
+            [1, 1, 0, null, null],
+            [2, 3, 3, null, null],
+        ]));
     }
 
     /**
@@ -58,10 +66,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_countable() : void
     {
-        $versions = new VersionsCollection(
-            Version::fromParts(1),
-            Version::fromString('1.1.0'),
-            Version::fromString('2.3.3')
+        $versions = VersionsCollection::fromStrings(
+            '1.0.0',
+            '1.1.0',
+            '2.3.3'
         );
 
         $this->assertCount(3, $versions);
@@ -82,10 +90,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_iterable() : void
     {
-        $versions = new VersionsCollection(
-            Version::fromParts(1),
-            Version::fromString('1.1.0'),
-            Version::fromString('2.3.3')
+        $versions = VersionsCollection::fromStrings(
+            '1.0.0',
+            '1.1.0',
+            '2.3.3'
         );
 
         foreach ($versions as $version) {
@@ -98,24 +106,24 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_sorted_in_ascending_order_by_default() : void
     {
-        $ordered = [
+        $versions = VersionsCollection::fromStrings(
+            '2.3.3',
+            '1.0.0',
+            '1.1.0',
+            '2.3.3-beta'
+        );
+
+        $versions->sort();
+
+        $expectedOrder = [
             '1.0.0',
             '1.1.0',
             '2.3.3-beta',
             '2.3.3',
         ];
 
-        $versions = new VersionsCollection(
-            Version::fromString('2.3.3'),
-            Version::fromParts(1),
-            Version::fromString('1.1.0'),
-            Version::fromString('2.3.3-beta')
-        );
-
-        $versions->sort();
-
         foreach ($versions as $key => $version) {
-            $this->assertSame($ordered[$key], (string) $version);
+            $this->assertSame($expectedOrder[$key], (string) $version);
         }
     }
 
@@ -124,22 +132,22 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_can_be_sorted_in_descending_order() : void
     {
-        $ordered = [
+        $versions = VersionsCollection::fromStrings(
+            '2.3.3',
+            '1.0.0',
+            '1.1.0'
+        );
+
+        $versions->sort(VersionsCollection::SORT_DESC);
+
+        $expectedOrder = [
             '2.3.3',
             '1.1.0',
             '1.0.0',
         ];
 
-        $versions = new VersionsCollection(
-            Version::fromString('2.3.3'),
-            Version::fromParts(1),
-            Version::fromString('1.1.0')
-        );
-
-        $versions->sort(VersionsCollection::SORT_DESC);
-
         foreach ($versions as $key => $version) {
-            $this->assertSame($ordered[$key], (string) $version);
+            $this->assertSame($expectedOrder[$key], (string) $version);
         }
     }
 
@@ -148,18 +156,20 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_filters_versions_that_match_constraint() : void
     {
-        $versions = new VersionsCollection(
-            Version::fromString('1.0.0'),
-            Version::fromString('1.0.1'),
-            Version::fromString('1.1.0'),
-            Version::fromString('2.0.0'),
-            Version::fromString('2.0.1')
+        $versions = VersionsCollection::fromStrings(
+            '1.0.0',
+            '1.0.1',
+            '1.1.0',
+            '2.0.0',
+            '2.0.1'
         );
 
         $versions2 = $versions->matching(ComparisonConstraint::fromString('>=2.0.0'));
 
-        $this->assertCount(5, $versions);
-        $this->assertCount(2, $versions2);
+        $this->assertThat($versions2, new VersionsCollectionIsIdentical([
+            [2, 0, 0, null, null],
+            [2, 0, 1, null, null],
+        ]));
     }
 
     /**

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -22,7 +22,7 @@ class VersionsCollectionTest extends TestCase
     public function it_can_be_created_via_constructor() : void
     {
         $versions = new VersionsCollection(
-            Version::fromParts(1),
+            Version::fromString('1.0.0'),
             Version::fromString('1.1.0'),
             Version::fromString('2.3.3')
         );
@@ -39,7 +39,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_can_be_created_from_version_strings() : void
     {
-        $versions = VersionsCollection::fromStrings('1.1.0', '2.3.3');
+        $versions = new VersionsCollection(
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3')
+        );
 
         $this->assertThat($versions, new VersionsCollectionIsIdentical([
             [1, 1, 0, null, null],
@@ -53,7 +56,10 @@ class VersionsCollectionTest extends TestCase
     public function it_forwards_invalid_version_string_exception() : void
     {
         try {
-            VersionsCollection::fromStrings('1.1.0', 'invalid');
+            new VersionsCollection(
+                Version::fromString('1.1.0'),
+                Version::fromString('invalid')
+            );
 
             $this->fail('Exception should have been raised');
         } catch (InvalidVersionStringException $ex) {
@@ -66,10 +72,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_countable() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '1.0.0',
-            '1.1.0',
-            '2.3.3'
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3')
         );
 
         $this->assertCount(3, $versions);
@@ -90,10 +96,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_iterable() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '1.0.0',
-            '1.1.0',
-            '2.3.3'
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3')
         );
 
         foreach ($versions as $version) {
@@ -106,11 +112,11 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_is_sorted_in_ascending_order_by_default() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '2.3.3',
-            '1.0.0',
-            '1.1.0',
-            '2.3.3-beta'
+        $versions = new VersionsCollection(
+            Version::fromString('2.3.3'),
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3-beta')
         );
 
         $versions->sort();
@@ -132,10 +138,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_can_be_sorted_in_descending_order() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '2.3.3',
-            '1.0.0',
-            '1.1.0'
+        $versions = new VersionsCollection(
+            Version::fromString('2.3.3'),
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0')
         );
 
         $versions->sort(VersionsCollection::SORT_DESC);
@@ -156,12 +162,11 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_filters_versions_that_match_constraint() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '1.0.0',
-            '1.0.1',
-            '1.1.0',
-            '2.0.0',
-            '2.0.1'
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.0.1'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.0.1')
         );
 
         $versions2 = $versions->matching(ComparisonConstraint::fromString('>=2.0.0'));
@@ -193,10 +198,10 @@ class VersionsCollectionTest extends TestCase
      */
     public function it_can_be_converted_to_an_array() : void
     {
-        $versions = VersionsCollection::fromStrings(
-            '1.0.0',
-            '1.0.1',
-            '1.1.0'
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.0.1'),
+            Version::fromString('1.1.0')
         );
 
         $versionsArray = $versions->toArray();

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -119,7 +119,7 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('2.3.3-beta')
         );
 
-        $versions->sort();
+        $versions = $versions->sorted();
 
         $expectedOrder = [
             '1.0.0',
@@ -144,12 +144,38 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('1.1.0')
         );
 
-        $versions->sort(VersionsCollection::SORT_DESC);
+        $versions = $versions->sorted(VersionsCollection::SORT_DESC);
 
         $expectedOrder = [
             '2.3.3',
             '1.1.0',
             '1.0.0',
+        ];
+
+        foreach ($versions as $key => $version) {
+            $this->assertSame($expectedOrder[$key], (string) $version);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_sorted_via_deprecated_sort_method() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('2.3.3'),
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.3.3-beta')
+        );
+
+        $versions->sort();
+
+        $expectedOrder = [
+            '1.0.0',
+            '1.1.0',
+            '2.3.3-beta',
+            '2.3.3',
         ];
 
         foreach ($versions as $key => $version) {

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -178,7 +178,7 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('2.3.3-beta')
         );
 
-        $versions = $versions->sorted();
+        $versions = $versions->sortedAscending();
 
         $expectedOrder = [
             '1.0.0',
@@ -203,7 +203,7 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('1.1.0')
         );
 
-        $versions = $versions->sorted(VersionsCollection::SORT_DESC);
+        $versions = $versions->sortedDescending();
 
         $expectedOrder = [
             '2.3.3',

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -177,4 +177,21 @@ class VersionsCollectionTest extends TestCase
 
         $this->assertCount(0, $versions2);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_be_converted_to_an_array() : void
+    {
+        $versions = VersionsCollection::fromStrings(
+            '1.0.0',
+            '1.0.1',
+            '1.1.0'
+        );
+
+        $versionsArray = $versions->toArray();
+
+        $this->assertContainsOnlyInstancesOf(Version::class, $versionsArray);
+        $this->assertCount(3, $versionsArray);
+    }
 }

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -308,6 +308,46 @@ class VersionsCollectionTest extends TestCase
     /**
      * @test
      */
+    public function it_filters_minor_versions() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.1.0'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.1.0')
+        );
+
+        $minorVersions = $versions->filterMinor();
+
+        $this->assertThat($minorVersions, new VersionsCollectionIsIdentical([
+            [1, 1, 0, null, null],
+            [2, 1, 0, null, null],
+        ]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_patch_versions() : void
+    {
+        $versions = new VersionsCollection(
+            Version::fromString('1.0.0'),
+            Version::fromString('1.0.1'),
+            Version::fromString('2.0.0'),
+            Version::fromString('2.0.1')
+        );
+
+        $minorVersions = $versions->filterMinor();
+
+        $this->assertThat($minorVersions, new VersionsCollectionIsIdentical([
+            [1, 0, 1, null, null],
+            [2, 0, 1, null, null],
+        ]));
+    }
+
+    /**
+     * @test
+     */
     public function it_can_be_converted_to_an_array() : void
     {
         $versions = new VersionsCollection(

--- a/tests/VersionsCollectionTest.php
+++ b/tests/VersionsCollectionTest.php
@@ -337,9 +337,9 @@ class VersionsCollectionTest extends TestCase
             Version::fromString('2.0.1')
         );
 
-        $minorVersions = $versions->filterMinor();
+        $patchVersions = $versions->filterPatch();
 
-        $this->assertThat($minorVersions, new VersionsCollectionIsIdentical([
+        $this->assertThat($patchVersions, new VersionsCollectionIsIdentical([
             [1, 0, 1, null, null],
             [2, 0, 1, null, null],
         ]));


### PR DESCRIPTION
Changes summary:
- Add `VersionsCollection::isEmpty()` method
- Add `VersionsCollection::toArray()` method
- Add immutable `VersionsCollection::sortedAscending()` and `VersionsCollection::sortedDescending()` methods; mark `VersionsCollection::sort()` as deprecated
- Add `VersionsCollection::first()` method
- Add `VersionsCollection::last()` method
- Add `VersionsCollection::majorReleases()` method
- Add `VersionsCollection::minorReleases()` method
- Add `VersionsCollection::patchReleases()` method