### PR TITLE
Fix comparison when identifier of pre release contains both letters and numbers

### DIFF
--- a/src/Extension/PreRelease.php
+++ b/src/Extension/PreRelease.php
@@ -38,14 +38,14 @@ class PreRelease extends BaseExtension
 
     private function compareIdentifiers($identifier1, $identifier2) : int
     {
-        $pr1IsAlpha = ctype_alpha($identifier1);
-        $pr2IsAlpha = ctype_alpha($identifier2);
+        $identifier1IsNumber = ctype_digit($identifier1);
+        $identifier2IsNumber = ctype_digit($identifier2);
 
-        if ($pr1IsAlpha xor $pr2IsAlpha) {
-            return $pr1IsAlpha ? 1 : -1;
+        if ($identifier1IsNumber xor $identifier2IsNumber) {
+            return $identifier1IsNumber ? -1 : 1;
         }
 
-        if (ctype_digit($identifier1) && ctype_digit($identifier2)) {
+        if ($identifier1IsNumber && $identifier2IsNumber) {
             return (int) $identifier1 - (int) $identifier2;
         }
 

--- a/tests/Comparator/SemverComparatorTest.php
+++ b/tests/Comparator/SemverComparatorTest.php
@@ -57,6 +57,7 @@ class SemverComparatorTest extends TestCase
             ['1.0.0-rc.1.1', '1.0.0-rc.1', 1],
             ['1.0.0', '1.0.0-rc.1', 1],
             ['1.0.0-alpha+20150919', '1.0.0-alpha+exp.sha.5114f85', 0],
+            ['1.0.0-b1', '1.0.0-a', 1],
         ];
     }
 }


### PR DESCRIPTION
Before a string containing both letters and numbers was treated wrong in the first check because `ctype_alpha()` returns false in that case.