### PR TITLE
Update Regex to accept dash between minor and patch number.

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -15,7 +15,7 @@ use Version\Extension\PreRelease;
 
 class Version implements JsonSerializable
 {
-    public const REGEX = '#^(?P<prefix>v|release\-)?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:\-(?P<preRelease>(?:0|[1-9]\d*|\d*[a-zA-Z\-][0-9a-zA-Z\-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z\-][0-9a-zA-Z\-]*))*))?(?:\+(?P<build>[0-9a-zA-Z\-]+(?:\.[0-9a-zA-Z\-]+)*))?$#';
+    public const REGEX = '#^(?P<prefix>v|release\-)?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.|\-)(?P<patch>0|[1-9]\d*)(?:\-(?P<preRelease>(?:0|[1-9]\d*|\d*[a-zA-Z\-][0-9a-zA-Z\-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z\-][0-9a-zA-Z\-]*))*))?(?:\+(?P<build>[0-9a-zA-Z\-]+(?:\.[0-9a-zA-Z\-]+)*))?$#';
 
     /** @var int */
     protected $major;


### PR DESCRIPTION
When a tag with major and minor version is created as `v0.5` it is complete with `-0-comithash` by the command : `git describe --tags --long 2>&1`.
In my project it returns `v0.5-0-gdb24e14d` wich doesn't match the current [regex](https://regexr.com/520d4). That's why I just replaced `\.` by `(\.|\-)` between minor and patch.