### PR TITLE
Explicit nullable types

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -31,7 +31,7 @@ class Version implements JsonSerializable
 
     protected static ?Comparator $comparator = null;
 
-    final protected function __construct(int $major, int $minor, int $patch, PreRelease $preRelease = null, Build $build = null)
+    final protected function __construct(int $major, int $minor, int $patch, ?PreRelease $preRelease = null, ?Build $build = null)
     {
         VersionAssert::that($major)->greaterOrEqualThan(0, 'Major version must be positive integer');
         VersionAssert::that($minor)->greaterOrEqualThan(0, 'Minor version must be positive integer');
@@ -44,7 +44,7 @@ class Version implements JsonSerializable
         $this->build = $build;
     }
 
-    public static function from(int $major, int $minor = 0, int $patch = 0, PreRelease $preRelease = null, Build $build = null): Version
+    public static function from(int $major, int $minor = 0, int $patch = 0, ?PreRelease $preRelease = null, ?Build $build = null): Version
     {
         return new static($major, $minor, $patch, $preRelease, $build);
     }


### PR DESCRIPTION
# What's Changed
The implicit nullable types are deprecated, I believe since php 8.4 a deprecation warning is issued when used. 

I updated the _Version_ class to explicit nullable types.